### PR TITLE
add liveness probe

### DIFF
--- a/charts/polkadot/templates/statefulset.yaml
+++ b/charts/polkadot/templates/statefulset.yaml
@@ -51,10 +51,10 @@ spec:
             path: /is_synced
             port: 31764
         livenessProbe:
-          # kill container after 20 minutes unsynced
+          # kill container after 40 minutes unsynced
           # that's enough time to not be chilled on kusama
           periodSeconds: 30
-          failureThreshold: 120
+          failureThreshold: 240
           timeoutSeconds: 10
           httpGet:
             path: /is_synced

--- a/charts/polkadot/templates/statefulset.yaml
+++ b/charts/polkadot/templates/statefulset.yaml
@@ -50,6 +50,23 @@ spec:
           httpGet:
             path: /is_synced
             port: 31764
+        livenessProbe:
+          # kill container after 20 minutes unsynced
+          # that's enough time to not be chilled on kusama
+          periodSeconds: 30
+          failureThreshold: 120
+          timeoutSeconds: 10
+          httpGet:
+            path: /is_synced
+            port: 31764
+        startupProbe:
+          # wait 4 hours for initial sync
+          periodSeconds: 30
+          failureThreshold: 1440
+          timeoutSeconds: 10
+          httpGet:
+            path: /is_synced
+            port: 31764
       - name: polkadot-sidecar
         image: {{ .Values.polkadot_k8s_images.polkadot_sidecar }}
         resources:


### PR DESCRIPTION
Restart the node after 20 minutes unsynced.

This would have prevented one slash today due to kusama issues.